### PR TITLE
[SharedKernel] feat: wire CurrentTenantService from JWT tenant_id claim

### DIFF
--- a/Sophrosynс/src/Shared/Sophrosync.SharedKernel/Services/CurrentTenantService.cs
+++ b/Sophrosynс/src/Shared/Sophrosync.SharedKernel/Services/CurrentTenantService.cs
@@ -4,6 +4,9 @@ using Sophrosync.SharedKernel.Security;
 
 namespace Sophrosync.SharedKernel.Services;
 
+// Spec ref: Architecture Spec Section 5 (SharedKernel) + Section 3.4 (Security Patterns)
+// Resolves tenant_id from the "tenant_id" custom JWT claim injected by Keycloak Protocol Mapper.
+// Returns Guid.Empty when the user is not authenticated — callers must check IsAvailable first.
 public sealed class CurrentTenantService(IHttpContextAccessor httpContextAccessor) : ICurrentTenant
 {
     public Guid Id
@@ -11,9 +14,9 @@ public sealed class CurrentTenantService(IHttpContextAccessor httpContextAccesso
         get
         {
             var user = httpContextAccessor.HttpContext?.User;
-            //if (user is null) throw new InvalidOperationException("No HTTP context available.");
-            //return user.GetTenantId();
-            return new Guid();
+            if (user is null || user.Identity?.IsAuthenticated != true)
+                return Guid.Empty;
+            return user.GetTenantId();
         }
     }
 


### PR DESCRIPTION
## Summary

Wires `CurrentTenantService.Id` to the real `tenant_id` JWT claim from Keycloak.

**Spec ref:** Architecture Spec Section 5 (SharedKernel), Section 3.4 (Security Patterns)

### Changes
- `CurrentTenantService.cs`: activates `user.GetTenantId()` â€” previously commented out and returning `new Guid()`.
- Returns `Guid.Empty` for unauthenticated callers (not thrown) â€” callers must check `IsAvailable` first.
- `KeycloakClaimsExtensions.GetTenantId()` is the single extraction path for `tenant_id` claim.

### Non-Negotiable Requirements
- [x] `tenant_id` extracted from JWT, not hardcoded or defaulted
- [x] `IsAvailable` guard respected â€” callers control unauthenticated behavior
- [x] No PHI in logs

### Review Checklist (Reviewer / OWASP A01)
- [ ] Confirm no cross-tenant data possible via `Guid.Empty` path
- [ ] Confirm EF Core global query filter remains active downstream
- [ ] Build: 0 errors
- [ ] Tests: 0 regressions

Closes #1 (partial â€” Workstream A1)