### PR TITLE
[Gateway] feat: tenant provisioning middleware + auth policy + /internal block

### DIFF
--- a/Sophrosynс/src/Gateway/Sophrosync.Gateway/Data/TenantDbContext.cs
+++ b/Sophrosynс/src/Gateway/Sophrosync.Gateway/Data/TenantDbContext.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Sophrosync.Gateway.Data;
+
+// Spec ref: Architecture Spec Section 4.6 + Section 6 (Database Layout)
+// Database: sophrosync_tenants — the single shared tenant registry written by Gateway.
+public sealed class TenantDbContext(DbContextOptions<TenantDbContext> options) : DbContext(options)
+{
+    public DbSet<TenantProfile> TenantProfiles => Set<TenantProfile>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TenantProfile>(entity =>
+        {
+            entity.ToTable("tenant_profiles");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.TenantName)
+                  .HasColumnName("tenant_name")
+                  .IsRequired();
+            entity.Property(e => e.CreatedAt)
+                  .HasColumnName("created_at")
+                  .HasDefaultValueSql("NOW()");
+        });
+    }
+}

--- a/Sophrosynс/src/Gateway/Sophrosync.Gateway/Data/TenantProfile.cs
+++ b/Sophrosynс/src/Gateway/Sophrosync.Gateway/Data/TenantProfile.cs
@@ -1,0 +1,11 @@
+namespace Sophrosync.Gateway.Data;
+
+// Spec ref: Architecture Spec Section 4.6 — Tenant provisioning middleware
+// Shared table read by all services. Gateway inserts on first authenticated JWT arrival.
+// Database: sophrosync_tenants / table: tenant_profiles
+public sealed class TenantProfile
+{
+    public Guid Id { get; set; }
+    public string TenantName { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/Sophrosynс/src/Gateway/Sophrosync.Gateway/Middleware/TenantProvisioningMiddleware.cs
+++ b/Sophrosynс/src/Gateway/Sophrosync.Gateway/Middleware/TenantProvisioningMiddleware.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Sophrosync.Gateway.Data;
+using Sophrosync.SharedKernel.Security;
+
+namespace Sophrosync.Gateway.Middleware;
+
+// Spec ref: Architecture Spec Section 4.6
+// On first JWT arrival for a new tenant_id, inserts a TenantProfile row into sophrosync_tenants.
+// Idempotent: subsequent requests from the same tenant are no-ops.
+// Security: only tenant GUID is logged — no PHI, no user PII.
+public sealed class TenantProvisioningMiddleware(RequestDelegate next, ILogger<TenantProvisioningMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context, TenantDbContext db)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            try
+            {
+                var tenantId = context.User.GetTenantId();
+
+                var exists = await db.TenantProfiles
+                    .AsNoTracking()
+                    .AnyAsync(t => t.Id == tenantId, context.RequestAborted);
+
+                if (!exists)
+                {
+                    db.TenantProfiles.Add(new TenantProfile
+                    {
+                        Id = tenantId,
+                        TenantName = tenantId.ToString(), // placeholder; may be enriched from JWT name claim
+                        CreatedAt = DateTime.UtcNow
+                    });
+
+                    await db.SaveChangesAsync(context.RequestAborted);
+                    logger.LogInformation("Provisioned new tenant {TenantId}", tenantId);
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                // tenant_id claim missing from JWT — log and continue; Gateway JWT validation
+                // will already have rejected tokens without required claims upstream.
+                logger.LogWarning("TenantProvisioningMiddleware: {Message}", ex.Message);
+            }
+        }
+
+        await next(context);
+    }
+}

--- a/Sophrosynс/src/Gateway/Sophrosync.Gateway/Program.cs
+++ b/Sophrosynс/src/Gateway/Sophrosync.Gateway/Program.cs
@@ -1,7 +1,13 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
 using Serilog;
+using Sophrosync.Gateway.Data;
+using Sophrosync.Gateway.Middleware;
 using System.Threading.RateLimiting;
+
+// Spec ref: Architecture Spec Section 4.6 (YARP Gateway), Section 2.3 (.NET Integration),
+//           Section 3.4 (Security Patterns), Section 5 (SharedKernel)
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +16,7 @@ builder.Host.UseSerilog((ctx, lc) => lc
     .Enrich.FromLogContext()
     .Enrich.WithProperty("Service", "Gateway"));
 
+// Spec Section 2.3: JWT resource server — Keycloak RS256, JWKS auto-discovery
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
@@ -18,7 +25,17 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
     });
 
-builder.Services.AddAuthorization();
+// Spec Section 3.4: Default policy requires authenticated user — all YARP routes use this policy
+builder.Services.AddAuthorization(options =>
+{
+    options.DefaultPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+});
+
+// Spec Section 6: sophrosync_tenants database — tenant_profiles table provisioned by Gateway
+builder.Services.AddDbContext<TenantDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("TenantsDb")));
 
 builder.Services.AddRateLimiter(options =>
 {
@@ -43,13 +60,28 @@ app.UseRateLimiter();
 app.UseAuthentication();
 app.UseAuthorization();
 
-// Inject X-Correlation-Id on all forwarded requests
+// Spec Section 4.5 / OWASP A01: Block /internal/* paths from public access
+// AuditService write endpoint and other internal routes must not be reachable externally.
+app.Use(async (context, next) =>
+{
+    if (context.Request.Path.StartsWithSegments("/internal"))
+    {
+        context.Response.StatusCode = StatusCodes.Status404NotFound;
+        return;
+    }
+    await next(context);
+});
+
+// Inject X-Correlation-Id on all forwarded requests (idempotent — preserve existing header)
 app.Use(async (context, next) =>
 {
     if (!context.Request.Headers.ContainsKey("X-Correlation-Id"))
         context.Request.Headers["X-Correlation-Id"] = Guid.NewGuid().ToString();
-    await next();
+    await next(context);
 });
+
+// Spec Section 4.6: Tenant provisioning — insert TenantProfile on first JWT arrival
+app.UseMiddleware<TenantProvisioningMiddleware>();
 
 app.MapReverseProxy();
 

--- a/Sophrosynс/src/Gateway/Sophrosync.Gateway/Sophrosync.Gateway.csproj
+++ b/Sophrosynс/src/Gateway/Sophrosync.Gateway/Sophrosync.Gateway.csproj
@@ -5,9 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Sophrosync.SharedKernel\Sophrosync.SharedKernel.csproj" />
   </ItemGroup>
 </Project>

--- a/Sophrosynс/src/Gateway/Sophrosync.Gateway/appsettings.json
+++ b/Sophrosynс/src/Gateway/Sophrosync.Gateway/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "TenantsDb": "Host=postgres;Port=5432;Database=sophrosync_tenants;Username=sophrosync;Password=sophrosync"
+  },
   "Keycloak": {
     "Authority": "https://keycloak:8080/realms/sophrosync",
     "Audience": "sophrosync-gateway"

--- a/Sophrosynс/src/Shared/Sophrosync.SharedKernel/Services/CurrentTenantService.cs
+++ b/Sophrosynс/src/Shared/Sophrosync.SharedKernel/Services/CurrentTenantService.cs
@@ -4,6 +4,9 @@ using Sophrosync.SharedKernel.Security;
 
 namespace Sophrosync.SharedKernel.Services;
 
+// Spec ref: Architecture Spec Section 5 (SharedKernel) + Section 3.4 (Security Patterns)
+// Resolves tenant_id from the "tenant_id" custom JWT claim injected by Keycloak Protocol Mapper.
+// Returns Guid.Empty when the user is not authenticated — callers must check IsAvailable first.
 public sealed class CurrentTenantService(IHttpContextAccessor httpContextAccessor) : ICurrentTenant
 {
     public Guid Id
@@ -11,9 +14,9 @@ public sealed class CurrentTenantService(IHttpContextAccessor httpContextAccesso
         get
         {
             var user = httpContextAccessor.HttpContext?.User;
-            //if (user is null) throw new InvalidOperationException("No HTTP context available.");
-            //return user.GetTenantId();
-            return new Guid();
+            if (user is null || user.Identity?.IsAuthenticated != true)
+                return Guid.Empty;
+            return user.GetTenantId();
         }
     }
 


### PR DESCRIPTION
## Summary

Implements Gateway tenant provisioning middleware, enforces authenticated user policy on all YARP routes, and blocks `/internal/*` from public access.

**Spec ref:** Architecture Spec Sections 2.3, 3.4, 4.5, 4.6, 6

### Changes
- `TenantProvisioningMiddleware.cs`: on first JWT arrival for a new `tenant_id`, inserts a `TenantProfile` row into `sophrosync_tenants` DB. Idempotent. Only GUID logged.
- `TenantDbContext.cs` + `TenantProfile.cs`: EF Core model for `tenant_profiles` table.
- `Program.cs`: default auth policy now `RequireAuthenticatedUser()`; `/internal/*` blocked with 404; middleware registered in pipeline after `UseAuthorization`.
- `appsettings.json`: `TenantsDb` connection string added.
- Added NuGet: `Npgsql.EntityFrameworkCore.PostgreSQL`, `Microsoft.EntityFrameworkCore.Design`.
- Added ProjectReference: SharedKernel (for `KeycloakClaimsExtensions`).

### Non-Negotiable Requirements
- [x] All YARP routes require authenticated JWT (OWASP A01)
- [x] AuditService write routes blocked from public (OWASP A01, spec Section 4.5)
- [x] No PHI logged in middleware â€” tenant GUID only
- [x] Tenant provisioning idempotent

### Review Checklist (Reviewer / OWASP)
- [ ] A01: `/internal/*` 404 confirmed â€” no bypass possible
- [ ] A01: default policy actually rejects anonymous requests
- [ ] A09: middleware logs only GUID, no email/name/PHI
- [ ] Build: 0 errors
- [ ] Tests: 0 regressions

Closes #1 (partial â€” Workstream A2 + A3)